### PR TITLE
Support tidb AUTO_INCREMENT with AUTH_CACHE_ID=1

### DIFF
--- a/api/db/migrate/20200219234329_devise_create_users.rb
+++ b/api/db/migrate/20200219234329_devise_create_users.rb
@@ -2,7 +2,7 @@
 
 class DeviseCreateUsers < ActiveRecord::Migration[5.1]
   def change
-    create_table :users do |t|
+    create_table(:users, options: 'AUTO_ID_CACHE 1') do |t|
       ## Database authenticatable
       t.string :email,              null: false, default: ''
       t.string :encrypted_password, null: false, default: ''

--- a/api/db/migrate/20200219235616_create_profiles.rb
+++ b/api/db/migrate/20200219235616_create_profiles.rb
@@ -2,7 +2,7 @@
 
 class CreateProfiles < ActiveRecord::Migration[5.1]
   def change
-    create_table :profiles do |t|
+    create_table(:profiles, options: 'AUTO_ID_CACHE 1') do |t|
       t.text :bio, null: true
       t.string :image_url
       t.belongs_to :user, null: false, index: { unique: true }, foreign_key: true

--- a/api/db/migrate/20200220001255_create_relationships.rb
+++ b/api/db/migrate/20200220001255_create_relationships.rb
@@ -2,7 +2,7 @@
 
 class CreateRelationships < ActiveRecord::Migration[5.1]
   def change
-    create_table :relationships do |t|
+    create_table(:relationships, options: 'AUTO_ID_CACHE 1') do |t|
       t.belongs_to :followed, null: false, foreign_key: { to_table: :users }, index: false
       t.belongs_to :follower, null: false, foreign_key: { to_table: :users }, index: false
 

--- a/api/db/migrate/20200220014408_create_articles.rb
+++ b/api/db/migrate/20200220014408_create_articles.rb
@@ -2,7 +2,7 @@
 
 class CreateArticles < ActiveRecord::Migration[5.1]
   def change
-    create_table :articles do |t|
+    create_table(:articles, options: 'AUTO_ID_CACHE 1') do |t|
       t.string :slug, null: false, index: { unique: true }
       t.string :title, null: false
       t.string :description, null: false

--- a/api/db/migrate/20200220014738_create_tags.rb
+++ b/api/db/migrate/20200220014738_create_tags.rb
@@ -2,7 +2,7 @@
 
 class CreateTags < ActiveRecord::Migration[5.1]
   def change
-    create_table :tags do |t|
+    create_table(:tags, options: 'AUTO_ID_CACHE 1') do |t|
       t.string :name, null: false, index: { unique: true }
       t.integer :taggings_count, null: false, default: 0
       t.timestamps

--- a/api/db/migrate/20200220014830_create_taggings.rb
+++ b/api/db/migrate/20200220014830_create_taggings.rb
@@ -2,7 +2,7 @@
 
 class CreateTaggings < ActiveRecord::Migration[5.1]
   def change
-    create_table :taggings do |t|
+    create_table(:taggings, options: 'AUTO_ID_CACHE 1') do |t|
       t.belongs_to :article, null: false, foreign_key: true, index: false
       t.belongs_to :tag, null: false, foreign_key: true, index: false
 

--- a/api/db/migrate/20200220015427_create_favorites.rb
+++ b/api/db/migrate/20200220015427_create_favorites.rb
@@ -2,7 +2,7 @@
 
 class CreateFavorites < ActiveRecord::Migration[5.1]
   def change
-    create_table :favorites do |t|
+    create_table(:favorites, options: 'AUTO_ID_CACHE 1') do |t|
       t.belongs_to :article, null: false, foreign_key: true, index: false
       t.belongs_to :user, null: false, foreign_key: true, index: false
 

--- a/api/db/migrate/20200220200738_create_comments.rb
+++ b/api/db/migrate/20200220200738_create_comments.rb
@@ -2,7 +2,7 @@
 
 class CreateComments < ActiveRecord::Migration[5.1]
   def change
-    create_table :comments do |t|
+    create_table(:comments, options: 'AUTO_ID_CACHE 1') do |t|
       t.belongs_to :author, null: false, foreign_key: { to_table: :users }
       t.belongs_to :article, null: false, foreign_key: true
       t.text :body, null: false

--- a/api/db/migrate/20200227021112_create_friendly_id_slugs.rb
+++ b/api/db/migrate/20200227021112_create_friendly_id_slugs.rb
@@ -9,7 +9,7 @@ MIGRATION_CLASS =
 
 class CreateFriendlyIdSlugs < MIGRATION_CLASS
   def change
-    create_table :friendly_id_slugs do |t|
+    create_table(:friendly_id_slugs, options: 'AUTO_ID_CACHE 1') do |t|
       t.string   :slug,           null: false
       t.integer  :sluggable_id,   null: false
       t.string   :sluggable_type, limit: 50

--- a/api/db/migrate/20211204034406_create_active_storage_tables.active_storage.rb
+++ b/api/db/migrate/20211204034406_create_active_storage_tables.active_storage.rb
@@ -1,7 +1,7 @@
 # This migration comes from active_storage (originally 20170806125915)
 class CreateActiveStorageTables < ActiveRecord::Migration[5.1]
   def change
-    create_table :active_storage_blobs do |t|
+    create_table(:active_storage_blobs, options: 'AUTO_ID_CACHE 1') do |t|
       t.string   :key,          null: false
       t.string   :filename,     null: false
       t.string   :content_type
@@ -14,7 +14,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.1]
       t.index [ :key ], unique: true
     end
 
-    create_table :active_storage_attachments do |t|
+    create_table(:active_storage_attachments, options: 'AUTO_ID_CACHE 1') do |t|
       t.string     :name,     null: false
       t.references :record,   null: false, polymorphic: true, index: false
       t.references :blob,     null: false
@@ -25,7 +25,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.1]
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
 
-    create_table :active_storage_variant_records do |t|
+    create_table(:active_storage_variant_records, options: 'AUTO_ID_CACHE 1') do |t|
       t.belongs_to :blob, null: false, index: false
       t.string :variation_digest, null: false
 

--- a/api/db/migrate/20211204034913_create_active_storage_variant_records.active_storage.rb
+++ b/api/db/migrate/20211204034913_create_active_storage_variant_records.active_storage.rb
@@ -2,7 +2,7 @@
 class CreateActiveStorageVariantRecords < ActiveRecord::Migration[5.1]
   def change
     unless table_exists?(:active_storage_variant_records)
-      create_table :active_storage_variant_records do |t|
+      create_table(:active_storage_variant_records, options: 'AUTO_ID_CACHE 1') do |t|
         t.belongs_to :blob, null: false, index: false
         t.string :variation_digest, null: false
 

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 20211204034913) do
 
-  create_table "active_storage_attachments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "active_storage_attachments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![auto_id_cache] AUTO_ID_CACHE=1 */" do |t|
     t.string "name", null: false
     t.string "record_type", null: false
     t.bigint "record_id", null: false
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 20211204034913) do
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "active_storage_blobs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![auto_id_cache] AUTO_ID_CACHE=1 */" do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -34,13 +34,13 @@ ActiveRecord::Schema.define(version: 20211204034913) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "active_storage_variant_records", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "active_storage_variant_records", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![auto_id_cache] AUTO_ID_CACHE=1 */" do |t|
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table "articles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "articles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![auto_id_cache] AUTO_ID_CACHE=1 */" do |t|
     t.string "slug", null: false
     t.string "title", null: false
     t.string "description", null: false
@@ -53,7 +53,7 @@ ActiveRecord::Schema.define(version: 20211204034913) do
     t.index ["slug"], name: "index_articles_on_slug", unique: true
   end
 
-  create_table "comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![auto_id_cache] AUTO_ID_CACHE=1 */" do |t|
     t.bigint "author_id", null: false
     t.bigint "article_id", null: false
     t.text "body", null: false
@@ -63,7 +63,7 @@ ActiveRecord::Schema.define(version: 20211204034913) do
     t.index ["author_id"], name: "index_comments_on_author_id"
   end
 
-  create_table "favorites", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "favorites", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![auto_id_cache] AUTO_ID_CACHE=1 */" do |t|
     t.bigint "article_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
@@ -73,7 +73,7 @@ ActiveRecord::Schema.define(version: 20211204034913) do
     t.index ["user_id"], name: "fk_rails_d15744e438"
   end
 
-  create_table "friendly_id_slugs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "friendly_id_slugs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![auto_id_cache] AUTO_ID_CACHE=1 */" do |t|
     t.string "slug", null: false
     t.integer "sluggable_id", null: false
     t.string "sluggable_type", limit: 50
@@ -84,7 +84,7 @@ ActiveRecord::Schema.define(version: 20211204034913) do
     t.index ["sluggable_type", "sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_type_and_sluggable_id"
   end
 
-  create_table "profiles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "profiles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![auto_id_cache] AUTO_ID_CACHE=1 */" do |t|
     t.text "bio"
     t.string "image_url"
     t.bigint "user_id", null: false
@@ -93,7 +93,7 @@ ActiveRecord::Schema.define(version: 20211204034913) do
     t.index ["user_id"], name: "index_profiles_on_user_id", unique: true
   end
 
-  create_table "relationships", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "relationships", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![auto_id_cache] AUTO_ID_CACHE=1 */" do |t|
     t.bigint "followed_id", null: false
     t.bigint "follower_id", null: false
     t.datetime "created_at", null: false
@@ -103,7 +103,7 @@ ActiveRecord::Schema.define(version: 20211204034913) do
     t.index ["follower_id"], name: "fk_rails_8c9a6d4759"
   end
 
-  create_table "taggings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "taggings", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![auto_id_cache] AUTO_ID_CACHE=1 */" do |t|
     t.bigint "article_id", null: false
     t.bigint "tag_id", null: false
     t.datetime "created_at", null: false
@@ -113,7 +113,7 @@ ActiveRecord::Schema.define(version: 20211204034913) do
     t.index ["tag_id"], name: "fk_rails_9fcd2e236b"
   end
 
-  create_table "tags", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "tags", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![auto_id_cache] AUTO_ID_CACHE=1 */" do |t|
     t.string "name", null: false
     t.integer "taggings_count", default: 0, null: false
     t.datetime "created_at", null: false
@@ -121,7 +121,7 @@ ActiveRecord::Schema.define(version: 20211204034913) do
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
-  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![auto_id_cache] AUTO_ID_CACHE=1 */" do |t|
     t.string "email", null: false
     t.string "encrypted_password", null: false
     t.string "reset_password_token"


### PR DESCRIPTION
ref: 
* https://docs.pingcap.com/tidb/stable/auto-increment#mysql-compatibility-mode
* https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-create_table

confirm:

```
mysql> show create table users\G
*************************** 1. row ***************************
       Table: users
Create Table: CREATE TABLE `users` (
  `id` bigint(20) NOT NULL AUTO_INCREMENT,
  `email` varchar(255) NOT NULL,
  `encrypted_password` varchar(255) NOT NULL,
  `reset_password_token` varchar(255) DEFAULT NULL,
  `reset_password_sent_at` datetime DEFAULT NULL,
  `remember_created_at` datetime DEFAULT NULL,
  `created_at` datetime NOT NULL,
  `updated_at` datetime NOT NULL,
  `followers_count` int(11) NOT NULL DEFAULT '0',
  `following_count` int(11) NOT NULL DEFAULT '0',
  `username` varchar(255) NOT NULL,
  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */,
  UNIQUE KEY `index_users_on_email` (`email`),
  UNIQUE KEY `index_users_on_reset_password_token` (`reset_password_token`),
  UNIQUE KEY `index_users_on_username` (`username`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin AUTO_INCREMENT=11 /*T![auto_id_cache] AUTO_ID_CACHE=1 */
1 row in set (0.00 sec)
```