### PR TITLE
fix proxysql warnings : variables in configuration-file

### DIFF
--- a/docker/proxysql/Dockerfile
+++ b/docker/proxysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM proxysql/proxysql:2.5.1
+FROM proxysql/proxysql:2.5.5
 RUN apt-get update && \
     apt-get install -y --no-install-recommends gettext-base && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/proxysql/proxysql.cnf.template
+++ b/docker/proxysql/proxysql.cnf.template
@@ -3,7 +3,7 @@ datadir="/var/lib/proxysql"
 admin_variables=
 {
     admin_credentials="admin:c9ApWNPHAfUz"
-    admin-web_enabled=false
+    web_enabled=false
     mysql_ifaces="0.0.0.0:6032"
 }
 
@@ -32,9 +32,9 @@ mysql_variables=
     ping_timeout_server=200
     commands_stats=true
     sessions_sort=true
-    mysql-max_stmts_per_connection=20
-    mysql-connection_max_age_ms=300000
-    mysql-connection_delay_multiplex_ms=0
+    max_stmts_per_connection=20
+    connection_max_age_ms=300000
+    connection_delay_multiplex_ms=0
 }
 
 mysql_servers =


### PR DESCRIPTION
fix this issue:
```
proxysql-1  | 2024-03-01 02:51:05 ProxySQL_Admin.cpp:6520:flush_admin_variables___database_to_runtime(): [WARNING] Impossible to set not existing variable admin-web_enabled with value "false". Deleting. If the variable name is correct, this version doesn't support it
proxysql-1  | 2024-03-01 02:51:05 [INFO] Computed checksum for 'LOAD ADMIN VARIABLES TO RUNTIME' was '0x2FD80815A82A32AA', with epoch '1709261465'
proxysql-1  | 2024-03-01 02:51:05 ProxySQL_Admin.cpp:6775:flush_mysql_variables___database_to_runtime(): [WARNING] Impossible to set not existing variable mysql-max_stmts_per_connection with value "20". Deleting. If the variable name is correct, this version doesn't support it
proxysql-1  | 2024-03-01 02:51:05 ProxySQL_Admin.cpp:6775:flush_mysql_variables___database_to_runtime(): [WARNING] Impossible to set not existing variable mysql-connection_max_age_ms with value "300000". Deleting. If the variable name is correct, this version doesn't support it
proxysql-1  | 2024-03-01 02:51:05 ProxySQL_Admin.cpp:6775:flush_mysql_variables___database_to_runtime(): [WARNING] Impossible to set not existing variable mysql-connection_delay_multiplex_ms with value "0". Deleting. If the variable name is correct, this version doesn't support it


MySQL [(none)]> SELECT * FROM global_variables WHERE variable_name LIKE 'mysql-max_stmts_per_connection';
+--------------------------------+----------------+
| variable_name                  | variable_value |
+--------------------------------+----------------+
| mysql-max_stmts_per_connection | 20             |
+--------------------------------+----------------+
1 row in set (0.001 sec)

MySQL [(none)]> SELECT * FROM global_variables WHERE variable_name LIKE 'mysql-connection_max_age_ms';
+-----------------------------+----------------+
| variable_name               | variable_value |
+-----------------------------+----------------+
| mysql-connection_max_age_ms | 0              |
+-----------------------------+----------------+
1 row in set (0.001 sec)

MySQL [(none)]> SELECT * FROM global_variables WHERE variable_name LIKE 'connection_delay_multiplex_ms';
Empty set (0.001 sec)
```

